### PR TITLE
[Fix] Not correctly display a portion of the BMP

### DIFF
--- a/bmp_lcd.c
+++ b/bmp_lcd.c
@@ -50,7 +50,7 @@ status_t display_segment_bmp(uint16_t x, uint16_t y, rectangle * area, bmp_image
 {
   loaderState->currentRow = area->top;
   uint16_t rowWidth = (area->right - area->left);
-  uint16_t targetY = y + area->bottom;
+  uint16_t targetY = y + area->bottom - area->top;
   init_draw(x, y, x+rowWidth-1, targetY-1);
   while(y < targetY)
   {


### PR DESCRIPTION
Fix the following issue:
- When trying to display a portion of the BMP onto the LCD, it does not work correctly, though it works fine if trying to display the top left of the BMP
  E.g.
  ```C
  rectangle rect;
  rect.top = 10;
  rect.left = 10; /* though it works fine if top and left are 0 */
  rect.bottom = 20;
  rect.right = 20;
  if (stat == STATUS_OK) {
      display_segment_bmp(0, 0, &rect, &image_state);
  }
  ```